### PR TITLE
docs: add missing project name "Inbox Zero" in Mail section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ Abandoned - Development Halted
 
 | Name | Description | Platform(s) | Stars |
 | --- | --- | --- | --- |
-| [](https://github.com/elie222/inbox-zero) | The world's best AI personal assistant for email. Open source app to help you reach inbox zero fast. | `Web (Cloud)` `SelfHost` | **9.2k** |
+| [Inbox Zero](https://github.com/elie222/inbox-zero) | The world's best AI personal assistant for email. Open source app to help you reach inbox zero fast. | `Web (Cloud)` `SelfHost` | **9.2k** |
 | [Himalaya](https://github.com/pimalaya/himalaya) `TUI` | CLI to manage emails | `Cross` | **5k** |
 | [Mailspring](https://github.com/Foundry376/Mailspring) | :love_letter: A beautiful, fast and fully open source mail client for Mac, Windows and Linux. | `Cross` | **16.8k** |
 | [ProtonMail](https://github.com/ProtonMail/WebClients) | Monorepo hosting the proton web clients | `Cross` `Mobile` | **5.1k** |


### PR DESCRIPTION
**By submitting this pull request I confirm that I have read and adhered to the contributing and submission guidelines to the best of my ability.**
This pull request fixes a minor documentation issue in the Mail section of the project’s README.md.
The entry for [inbox-zero](https://github.com/elie222/inbox-zero)
previously had an empty project name in the first column of the table.
This update fills in the missing name to improve readability and consistency.