### PR TITLE
Add Off Grid to LLM GUI

### DIFF
--- a/core/data/dynamic/applications.json
+++ b/core/data/dynamic/applications.json
@@ -12969,6 +12969,22 @@
             "language": "TypeScript",
             "license": "GPL-3.0",
             "homepage_url": "https://dearrow.ajay.app"
+        },
+        {
+            "name": "Off Grid",
+            "description": "",
+            "repo_url": "https://github.com/alichherawalla/off-grid-mobile",
+            "tags": [],
+            "platforms": [
+                "mobile"
+            ],
+            "category": "llm-gui",
+            "stars": 0,
+            "flags": [],
+            "last_commit": "",
+            "language": "",
+            "license": "",
+            "homepage_url": ""
         }
     ]
 }


### PR DESCRIPTION
Adds [Off Grid](https://github.com/alichherawalla/off-grid-mobile) — an open-source, consumer-facing AI suite that runs entirely on-device.

### What it does
- On-device LLM chat via llama.cpp
- Vision model support (SmolVLM, LLaVA)
- On-device image generation via Stable Diffusion
- No cloud, no API keys, no data collection

### Download
- [App Store](https://apps.apple.com/in/app/off-grid-on-device-ai/id6740649499)
- [Google Play](https://play.google.com/store/apps/details?id=ai.offgridmobile)
- [APK](https://github.com/alichherawalla/off-grid-mobile/releases)