### PR TITLE
Generate Removed Projects from archive.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1803,28 +1803,18 @@ Abandoned - Development Halted
 | [XPipe](https://github.com/xpipe-io/xpipe) | Access your entire server infrastructure from your local desktop | `Cross` | **14k** |
 
 
-
-## Honorable Mentions of Closed-Source Software
-Some proprietary software just deserve recognition.
-- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
-- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
-- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
-- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
-- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
-
 ## Removed Projects
-Projects that were once on this list but removed - usually due to abandonement or going closed source. 
+Projects that were once on this list but removed, usually due to abandonment or going closed source.
 
 <details>
   <summary><b>Archive</b></summary> <br />
-  
-  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed source`
+
+  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed Source`
   - [Hyper](https://github.com/vercel/hyper) - `Abandoned`
-  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed source`
+  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed Source`
   - [Lunarvim](https://github.com/LunarVim/LunarVim) - `Abandoned`
   - [Motrix](https://github.com/agalwood/Motrix) - `Abandoned`
   - [StableSwarmUI](https://github.com/Stability-AI/StableSwarmUI) - `Abandoned`
-  - [Trilium](https://github.com/zadam/trilium) - `Abandoned`
   - [Whisky](https://github.com/Whisky-App/Whisky) - `Abandoned`
   - [SpaceVim](https://github.com/SpaceVim/SpaceVim) - `Abandoned`
   - [Readarr](https://github.com/Readarr/Readarr) - `Abandoned`
@@ -1844,8 +1834,17 @@ Projects that were once on this list but removed - usually due to abandonement o
   - [Reor](https://github.com/reorproject/reor) - `Archived`
   - [Jellyfin Desktop](https://github.com/jellyfin-archive/jellyfin-desktop-qt/) - `Archived`
   - [Battery Toolkit](https://github.com/mhaeuser/Battery-Toolkit) - `Archived`
-  - Booklore - `Deleted`
+  - [Booklore](https://github.com/booklore-app/booklore) - `Deleted`
 </details>
+
+
+## Honorable Mentions of Closed-Source Software
+Some proprietary software just deserve recognition.
+- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
+- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
+- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
+- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
+- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
 
 ## FAQ
 <details>

--- a/core/components/footer.md
+++ b/core/components/footer.md
@@ -7,41 +7,6 @@ Some proprietary software just deserve recognition.
 - [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
 - [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
 
-## Removed Projects
-Projects that were once on this list but removed - usually due to abandonement or going closed source. 
-
-<details>
-  <summary><b>Archive</b></summary> <br />
-  
-  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed source`
-  - [Hyper](https://github.com/vercel/hyper) - `Abandoned`
-  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed source`
-  - [Lunarvim](https://github.com/LunarVim/LunarVim) - `Abandoned`
-  - [Motrix](https://github.com/agalwood/Motrix) - `Abandoned`
-  - [StableSwarmUI](https://github.com/Stability-AI/StableSwarmUI) - `Abandoned`
-  - [Trilium](https://github.com/zadam/trilium) - `Abandoned`
-  - [Whisky](https://github.com/Whisky-App/Whisky) - `Abandoned`
-  - [SpaceVim](https://github.com/SpaceVim/SpaceVim) - `Abandoned`
-  - [Readarr](https://github.com/Readarr/Readarr) - `Abandoned`
-  - [Lenovo Legion Toolkit](https://github.com/BartoszCichecki/LenovoLegionToolkit) - `Abandoned`
-  - [Cody](https://github.com/sourcegraph/cody-public-snapshot) - `Closed Source`
-  - [Maybe](https://github.com/maybe-finance/maybe) - `Closed Source`
-  - [Spyglass](https://github.com/spyglass-search/spyglass) - `Abandoned`
-  - [myDrive](https://github.com/subnub/myDrive) - `Abandoned`
-  - [VimWiki](https://github.com/vimwiki/vimwiki) - `Abandoned`
-  - [Olive](https://github.com/olive-editor/olive) - `Abandoned`
-  - [PairDrop](https://github.com/schlagmichdoch/PairDrop) - `Abandoned`
-  - [HTTPie CLI](https://github.com/httpie/cli) - `Abandoned`
-  - [fswatch](https://github.com/emcrisostomo/fswatch) - `Abandoned`
-  - [AgentGPT](https://github.com/reworkd/agentgpt) - `Archived`
-  - [h2oGPT](https://github.com/h2oai/h2ogpt) - `Archived`
-  - [Overseerr](https://github.com/sct/overseerr?tab=readme-ov-file) - `Archived`
-  - [Reor](https://github.com/reorproject/reor) - `Archived`
-  - [Jellyfin Desktop](https://github.com/jellyfin-archive/jellyfin-desktop-qt/) - `Archived`
-  - [Battery Toolkit](https://github.com/mhaeuser/Battery-Toolkit) - `Archived`
-  - Booklore - `Deleted`
-</details>
-
 ## FAQ
 <details>
   <summary><b>Stars aren't a good metric to guage popularity/quality.</b></summary> <br />

--- a/core/source/generation/archive_generator.py
+++ b/core/source/generation/archive_generator.py
@@ -1,0 +1,54 @@
+import json
+
+
+REASON_LABELS = {
+    "closed-source": "Closed Source",
+    "closed source": "Closed Source",
+    "abandoned": "Abandoned",
+    "archived": "Archived",
+    "deleted": "Deleted",
+}
+
+
+def format_reason(reason):
+    if not reason:
+        return "Unknown"
+
+    normalized = reason.strip().lower()
+    if normalized in REASON_LABELS:
+        return REASON_LABELS[normalized]
+
+    return reason.strip().title()
+
+
+def generate_archive_section():
+    with open("data/dynamic/archive.json", "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    applications = data.get("applications", [])
+
+    lines = [
+        "## Removed Projects",
+        "Projects that were once on this list but removed, usually due to abandonment or going closed source.",
+        "",
+        "<details>",
+        "  <summary><b>Archive</b></summary> <br />",
+        "",
+    ]
+
+    for app in applications:
+        name = app.get("name", "Unknown Project")
+        repo_url = app.get("repo_url", "").strip()
+        reason = format_reason(app.get("reason", "Unknown"))
+
+        if repo_url:
+            lines.append(f"  - [{name}]({repo_url}) - `{reason}`")
+        else:
+            lines.append(f"  - {name} - `{reason}`")
+
+    lines.extend(["</details>", ""])
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(generate_archive_section())

--- a/core/source/generation/readme_generator.py
+++ b/core/source/generation/readme_generator.py
@@ -1,3 +1,4 @@
+from archive_generator import generate_archive_section
 from contents_generator import generate_contents
 from mainheader_generator import generate_mainheader
 from tableofcontents_generator import generate_table_of_contents
@@ -33,6 +34,9 @@ def generate_readme_for_platform(platform):
 
     contents_md = generate_contents(platform)
     content += contents_md + "\n"
+
+    archive_md = generate_archive_section()
+    content += archive_md + "\n"
 
     with open("components/footer.md", "r", encoding="utf-8") as f:
         content += f.read() + "\n"

--- a/resources/readmes/linux.md
+++ b/resources/readmes/linux.md
@@ -1397,28 +1397,18 @@
 | [XPipe](https://github.com/xpipe-io/xpipe) | Access your entire server infrastructure from your local desktop | `Cross` | **14k** |
 
 
-
-## Honorable Mentions of Closed-Source Software
-Some proprietary software just deserve recognition.
-- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
-- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
-- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
-- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
-- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
-
 ## Removed Projects
-Projects that were once on this list but removed - usually due to abandonement or going closed source. 
+Projects that were once on this list but removed, usually due to abandonment or going closed source.
 
 <details>
   <summary><b>Archive</b></summary> <br />
-  
-  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed source`
+
+  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed Source`
   - [Hyper](https://github.com/vercel/hyper) - `Abandoned`
-  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed source`
+  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed Source`
   - [Lunarvim](https://github.com/LunarVim/LunarVim) - `Abandoned`
   - [Motrix](https://github.com/agalwood/Motrix) - `Abandoned`
   - [StableSwarmUI](https://github.com/Stability-AI/StableSwarmUI) - `Abandoned`
-  - [Trilium](https://github.com/zadam/trilium) - `Abandoned`
   - [Whisky](https://github.com/Whisky-App/Whisky) - `Abandoned`
   - [SpaceVim](https://github.com/SpaceVim/SpaceVim) - `Abandoned`
   - [Readarr](https://github.com/Readarr/Readarr) - `Abandoned`
@@ -1438,8 +1428,17 @@ Projects that were once on this list but removed - usually due to abandonement o
   - [Reor](https://github.com/reorproject/reor) - `Archived`
   - [Jellyfin Desktop](https://github.com/jellyfin-archive/jellyfin-desktop-qt/) - `Archived`
   - [Battery Toolkit](https://github.com/mhaeuser/Battery-Toolkit) - `Archived`
-  - Booklore - `Deleted`
+  - [Booklore](https://github.com/booklore-app/booklore) - `Deleted`
 </details>
+
+
+## Honorable Mentions of Closed-Source Software
+Some proprietary software just deserve recognition.
+- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
+- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
+- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
+- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
+- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
 
 ## FAQ
 <details>

--- a/resources/readmes/macos.md
+++ b/resources/readmes/macos.md
@@ -1434,28 +1434,18 @@
 | [XPipe](https://github.com/xpipe-io/xpipe) | Access your entire server infrastructure from your local desktop | `Cross` | **14k** |
 
 
-
-## Honorable Mentions of Closed-Source Software
-Some proprietary software just deserve recognition.
-- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
-- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
-- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
-- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
-- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
-
 ## Removed Projects
-Projects that were once on this list but removed - usually due to abandonement or going closed source. 
+Projects that were once on this list but removed, usually due to abandonment or going closed source.
 
 <details>
   <summary><b>Archive</b></summary> <br />
-  
-  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed source`
+
+  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed Source`
   - [Hyper](https://github.com/vercel/hyper) - `Abandoned`
-  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed source`
+  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed Source`
   - [Lunarvim](https://github.com/LunarVim/LunarVim) - `Abandoned`
   - [Motrix](https://github.com/agalwood/Motrix) - `Abandoned`
   - [StableSwarmUI](https://github.com/Stability-AI/StableSwarmUI) - `Abandoned`
-  - [Trilium](https://github.com/zadam/trilium) - `Abandoned`
   - [Whisky](https://github.com/Whisky-App/Whisky) - `Abandoned`
   - [SpaceVim](https://github.com/SpaceVim/SpaceVim) - `Abandoned`
   - [Readarr](https://github.com/Readarr/Readarr) - `Abandoned`
@@ -1475,8 +1465,17 @@ Projects that were once on this list but removed - usually due to abandonement o
   - [Reor](https://github.com/reorproject/reor) - `Archived`
   - [Jellyfin Desktop](https://github.com/jellyfin-archive/jellyfin-desktop-qt/) - `Archived`
   - [Battery Toolkit](https://github.com/mhaeuser/Battery-Toolkit) - `Archived`
-  - Booklore - `Deleted`
+  - [Booklore](https://github.com/booklore-app/booklore) - `Deleted`
 </details>
+
+
+## Honorable Mentions of Closed-Source Software
+Some proprietary software just deserve recognition.
+- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
+- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
+- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
+- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
+- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
 
 ## FAQ
 <details>

--- a/resources/readmes/selfhost.md
+++ b/resources/readmes/selfhost.md
@@ -1182,28 +1182,18 @@
 | [Pangolin](https://github.com/fosrl/pangolin) | Identity-aware VPN and proxy for remote access to anything, anywhere. | `SelfHost` | **20.2k** |
 
 
-
-## Honorable Mentions of Closed-Source Software
-Some proprietary software just deserve recognition.
-- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
-- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
-- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
-- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
-- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
-
 ## Removed Projects
-Projects that were once on this list but removed - usually due to abandonement or going closed source. 
+Projects that were once on this list but removed, usually due to abandonment or going closed source.
 
 <details>
   <summary><b>Archive</b></summary> <br />
-  
-  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed source`
+
+  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed Source`
   - [Hyper](https://github.com/vercel/hyper) - `Abandoned`
-  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed source`
+  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed Source`
   - [Lunarvim](https://github.com/LunarVim/LunarVim) - `Abandoned`
   - [Motrix](https://github.com/agalwood/Motrix) - `Abandoned`
   - [StableSwarmUI](https://github.com/Stability-AI/StableSwarmUI) - `Abandoned`
-  - [Trilium](https://github.com/zadam/trilium) - `Abandoned`
   - [Whisky](https://github.com/Whisky-App/Whisky) - `Abandoned`
   - [SpaceVim](https://github.com/SpaceVim/SpaceVim) - `Abandoned`
   - [Readarr](https://github.com/Readarr/Readarr) - `Abandoned`
@@ -1223,8 +1213,17 @@ Projects that were once on this list but removed - usually due to abandonement o
   - [Reor](https://github.com/reorproject/reor) - `Archived`
   - [Jellyfin Desktop](https://github.com/jellyfin-archive/jellyfin-desktop-qt/) - `Archived`
   - [Battery Toolkit](https://github.com/mhaeuser/Battery-Toolkit) - `Archived`
-  - Booklore - `Deleted`
+  - [Booklore](https://github.com/booklore-app/booklore) - `Deleted`
 </details>
+
+
+## Honorable Mentions of Closed-Source Software
+Some proprietary software just deserve recognition.
+- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
+- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
+- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
+- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
+- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
 
 ## FAQ
 <details>

--- a/resources/readmes/windows.md
+++ b/resources/readmes/windows.md
@@ -1400,28 +1400,18 @@
 | [XPipe](https://github.com/xpipe-io/xpipe) | Access your entire server infrastructure from your local desktop | `Cross` | **14k** |
 
 
-
-## Honorable Mentions of Closed-Source Software
-Some proprietary software just deserve recognition.
-- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
-- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
-- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
-- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
-- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
-
 ## Removed Projects
-Projects that were once on this list but removed - usually due to abandonement or going closed source. 
+Projects that were once on this list but removed, usually due to abandonment or going closed source.
 
 <details>
   <summary><b>Archive</b></summary> <br />
-  
-  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed source`
+
+  - [eqMac](https://github.com/bitgapp/eqMac) - `Closed Source`
   - [Hyper](https://github.com/vercel/hyper) - `Abandoned`
-  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed source`
+  - [DiffusionBee](https://github.com/divamgupta/diffusionbee-stable-diffusion-ui) - `Closed Source`
   - [Lunarvim](https://github.com/LunarVim/LunarVim) - `Abandoned`
   - [Motrix](https://github.com/agalwood/Motrix) - `Abandoned`
   - [StableSwarmUI](https://github.com/Stability-AI/StableSwarmUI) - `Abandoned`
-  - [Trilium](https://github.com/zadam/trilium) - `Abandoned`
   - [Whisky](https://github.com/Whisky-App/Whisky) - `Abandoned`
   - [SpaceVim](https://github.com/SpaceVim/SpaceVim) - `Abandoned`
   - [Readarr](https://github.com/Readarr/Readarr) - `Abandoned`
@@ -1441,8 +1431,17 @@ Projects that were once on this list but removed - usually due to abandonement o
   - [Reor](https://github.com/reorproject/reor) - `Archived`
   - [Jellyfin Desktop](https://github.com/jellyfin-archive/jellyfin-desktop-qt/) - `Archived`
   - [Battery Toolkit](https://github.com/mhaeuser/Battery-Toolkit) - `Archived`
-  - Booklore - `Deleted`
+  - [Booklore](https://github.com/booklore-app/booklore) - `Deleted`
 </details>
+
+
+## Honorable Mentions of Closed-Source Software
+Some proprietary software just deserve recognition.
+- [Davinci Resolve](https://www.blackmagicdesign.com/products/davinciresolve) - Professional Editing, Color, Effects and Audio Post!
+- [Obsidian](https://obsidian.md/) - The free and flexible app for your private thoughts. 
+- [LM Studio](https://lmstudio.ai/) - Discover, download, and run local LLMs
+- [JetBrains](https://www.jetbrains.com/) - A rich suite of tools that provide an exceptional developer experience
+- [Raycast](https://www.raycast.com/) - A collection of powerful productivity tools all within an extendable launcher.
 
 ## FAQ
 <details>


### PR DESCRIPTION
## Summary
- generate the Removed Projects section from `core/data/dynamic/archive.json`
- move archive rendering out of the hardcoded footer markdown
- regenerate the main README and platform-specific READMEs

## Why
The repo already stores archive data in JSON, but the README output was still maintained manually in `core/components/footer.md`. This change makes `archive.json` the source of truth for the Removed Projects section while keeping the rendered output behavior the same.

## Testing
- ran `python3 source/generation/readme_generator.py` from `core/`
- verified the Removed Projects section still appears in `README.md` and generated platform READMEs
