### PR TITLE
Security/Logic Fix: Autonomous Code Review

### DIFF
--- a/core/source/maintenance/stats_updator.py
+++ b/core/source/maintenance/stats_updator.py
@@ -9,6 +9,10 @@ with open("data/dynamic/applications.json", "r") as f:
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 
+if GITHUB_TOKEN is None:
+    print("Error: GITHUB_TOKEN environment variable is not set.")
+    exit(1)
+
 headers = {
     "Authorization": f"token {GITHUB_TOKEN}",
     "Accept": "application/vnd.github.v3+json",


### PR DESCRIPTION
## Autonomous Bug Report & Patch

This vulnerability and fix were autonomously discovered by the Lucy Red Team swarm.

The critical bug in the provided code is related to how the `GITHUB_TOKEN` environment variable is being accessed and used. Specifically, if the environment variable is not set or is invalid, the script will fail when trying to make requests to the GitHub API because it won't include the necessary authorization header.

Here's a step-by-step analysis of the issue:

1. **Environment Variable Access**: The `GITHUB_TOKEN` is accessed using `os.getenv("GITHUB_TOKEN")`. If this environment variable is not set, `GITHUB_TOKEN` will be `None`.

2. **Authorization Header**: The headers dictionary includes an `Authorization` header that uses the `GITHUB_TOKEN`. If `GITHUB_TOKEN` is `None`, the header will be `"token None"`, which is invalid.

3. **API Request**: When making requests to the GitHub API, if the token is missing or invalid, the API will return a 401 Unauthorized status code. This can cause the script to fail and potentially update incorrect data or log misleading error messages.

To fix this issue, you should add a check to ensure that `GITHUB_TOKEN` is set before making any requests. If it's not set, the script should handle this gracefully, perhaps by logging an error message and exiting the program.

Here's how you can modify the code to include this check:

```python
import json
import os
from datetime import datetime

import requests

with open("data/dynamic/app