### PR TITLE
Add ReactOS to operating-system

### DIFF
--- a/core/data/dynamic/applications.json
+++ b/core/data/dynamic/applications.json
@@ -13424,6 +13424,22 @@
             "language": "Objective-C",
             "license": "BSD-3-Clause",
             "homepage_url": ""
+        },
+        {
+            "name": "ReactOS",
+            "description": "A free Windows-compatible Operating System",
+            "repo_url": "https://github.com/reactos/reactos",
+            "tags": [],
+            "platforms": [
+                "n/a"
+            ],
+            "category": "operating-system",
+            "stars": 0,
+            "flags": [],
+            "last_commit": "",
+            "language": "",
+            "license": "",
+            "homepage_url": ""
         }
     ]
 }


### PR DESCRIPTION
Adds ReactOS (https://github.com/reactos/reactos) to the operating-system category in core/data/dynamic/applications.json per CONTRIBUTING.md.